### PR TITLE
Fixed composer install line

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -37,7 +37,7 @@ As you can see, Gestalt is sweet and simple to play with right out of the box. I
 ## Installation
 Install via Composer:
 
-`composer install samrap/gestalt`
+`composer require samrap/gestalt`
 
 ## Usage
 


### PR DESCRIPTION
Changed composer install line to use the proper `require` instead of `install`.
