### PR TITLE
Reads the contents of the json file, tests for value in array.

### DIFF
--- a/src/Gestalt/Loaders/DirectoryLoader.php
+++ b/src/Gestalt/Loaders/DirectoryLoader.php
@@ -53,7 +53,7 @@ abstract class DirectoryLoader implements LoaderInterface
                 $filename = $file->getFilename();
                 $config = substr($filename, 0, strrpos($filename, '.'));
 
-                $items[$config] = $this->translateFile($file->getPathName());
+                $items[$config] = $this->translateFile($file->getPathname());
             }
         }
 

--- a/src/Gestalt/Loaders/JsonDirectoryLoader.php
+++ b/src/Gestalt/Loaders/JsonDirectoryLoader.php
@@ -19,6 +19,6 @@ class JsonDirectoryLoader extends DirectoryLoader
      */
     public function translateFile($filePath)
     {
-        return json_decode($filePath);
+        return json_decode(file_get_contents($filePath));
     }
 }

--- a/tests/JsonDirectoryLoader.php
+++ b/tests/JsonDirectoryLoader.php
@@ -7,8 +7,12 @@ class JsonDirectoryLoaderTest extends TestCase
     public function test_load_method_returns_configuration_array()
     {
         $loader = new JsonDirectoryLoader(__DIR__.'/config');
-        $loaded = $loader->load();
+        $loadedConfig = $loader->load();
 
-        $this->assertArrayHasKey('foobar', $loaded);
+        // Checks the file name is the main key
+        $this->assertArrayHasKey('foobar', $loadedConfig);
+
+        // Checks that the value in the config is decoded
+        $this->assertTrue($loadedConfig['foobar']->foobar);
     }
 }


### PR DESCRIPTION
The test passed because the first key in the loaded configuration is the file name. Testing for the contents fails so I added an assertion for that.

Also I fixed the `getPathname()` method name: http://php.net/manual/en/directoryiterator.getpathname.php
